### PR TITLE
Allow multiple ntuple reading

### DIFF
--- a/dtpr/base/event.py
+++ b/dtpr/base/event.py
@@ -28,7 +28,7 @@ class Event:
         (e.g., `event.genmuons`).
     """
 
-    def __init__(self, ev=None, index=None, use_config=False):
+    def __init__(self, ev=None, index=None, use_config=False, CONFIG=None):
         """
         Initialize an Event instance.
 
@@ -41,13 +41,13 @@ class Event:
         self.index = index
         self.number = index
         self._particles = {}  # Initialize an empty dictionary for particles
-
+        CONFIG_ = CONFIG if CONFIG is not None else RUN_CONFIG
         if ev is not None:
             # Default to the index if the event number is not found
             self.number = getattr(ev, "event_eventNumber", self.number)
 
-        if use_config and hasattr(RUN_CONFIG, "particle_types"):
-            for ptype, pinfo in getattr(RUN_CONFIG, "particle_types", {}).items():
+        if use_config and hasattr(CONFIG_, "particle_types"):
+            for ptype, pinfo in getattr(CONFIG_, "particle_types", {}).items():
                 self._build_particles(ev, ptype, pinfo)
         else:
             warnings.warn(

--- a/dtpr/base/event_list.py
+++ b/dtpr/base/event_list.py
@@ -1,4 +1,5 @@
 from .event import Event
+from .config import RUN_CONFIG
 
 
 class EventList:
@@ -6,7 +7,7 @@ class EventList:
     A class to manage events such as a list, but without loading all events in memory.
     """
 
-    def __init__(self, tree, processor=None):
+    def __init__(self, tree, processor=None, CONFIG=None):
         """
         Initialize an EventList instance.
 
@@ -20,6 +21,7 @@ class EventList:
         self._tree = tree
         self._processor = processor
         self._length = tree.GetEntries()
+        self.CONFIG = CONFIG if CONFIG is not None else RUN_CONFIG
 
     def __len__(self):
         """
@@ -50,7 +52,7 @@ class EventList:
 
             for iev, ev in enumerate(self._tree):
                 if iev == index:
-                    event = Event(ev, iev, use_config=True)
+                    event = Event(ev, iev, use_config=True, CONFIG=self.CONFIG)
                     if self._processor:
                         return self._processor(event)
                     else:
@@ -73,7 +75,7 @@ class EventList:
         """
         for iev, ev in enumerate(self._tree):
             if getattr(ev, "event_eventNumber", None) == number:
-                event = Event(ev, iev, use_config=True)
+                event = Event(ev, iev, use_config=True, CONFIG=self.CONFIG)
                 return self._processor(event)
         raise ValueError(f"No event found with number: {number}")
 
@@ -82,7 +84,7 @@ class EventList:
         Iterate over the events in the EventList.
         """
         for iev, ev in enumerate(self._tree):
-            event = Event(ev, iev, use_config=True)
+            event = Event(ev, iev, use_config=True, CONFIG=self.CONFIG)
             yield self._processor(event)
 
     def __repr__(self):


### PR DESCRIPTION
This close #10 

This pull request introduces support for passing a custom configuration object (`CONFIG`) throughout the event and ntuple handling classes, instead of relying solely on the global `RUN_CONFIG`. This change improves flexibility and testability by allowing different configurations to be used in different contexts. The most important changes are grouped below:

**Configuration Handling Improvements**

* Added an optional `CONFIG` parameter to the constructors of `Event`, `EventList`, and `NTuple`, allowing these classes to use a custom configuration object instead of the global `RUN_CONFIG`. (`dtpr/base/event.py`, `dtpr/base/event_list.py`, `dtpr/base/ntuple.py`) [[1]](diffhunk://#diff-c3e52fa5e66c636f907d4685b7d12530b4e22221827483dc7181ad10423267faL31-R31) [[2]](diffhunk://#diff-bbd0729f87a1ee0b3d09bfa79d64bf41adf24bd3a75d54bc87f72fe74bf183d0R2-R10) [[3]](diffhunk://#diff-0ec8f91651c02d91e3c81f4b4ca1764bb449a61b1e461806bc3752a06d0e1bf1L24-R24)
* Updated all internal references to configuration-dependent attributes and methods to use the provided `CONFIG` object, falling back to `RUN_CONFIG` if none is provided. (`dtpr/base/event.py`, `dtpr/base/event_list.py`, `dtpr/base/ntuple.py`) [[1]](diffhunk://#diff-c3e52fa5e66c636f907d4685b7d12530b4e22221827483dc7181ad10423267faL44-R50) [[2]](diffhunk://#diff-bbd0729f87a1ee0b3d09bfa79d64bf41adf24bd3a75d54bc87f72fe74bf183d0R24) [[3]](diffhunk://#diff-0ec8f91651c02d91e3c81f4b4ca1764bb449a61b1e461806bc3752a06d0e1bf1L39-R47)

**Event and EventList Usage**

* Ensured that when creating `Event` instances within `EventList`, the correct `CONFIG` object is passed, maintaining configuration consistency throughout event processing and iteration. (`dtpr/base/event_list.py`) [[1]](diffhunk://#diff-bbd0729f87a1ee0b3d09bfa79d64bf41adf24bd3a75d54bc87f72fe74bf183d0L53-R55) [[2]](diffhunk://#diff-bbd0729f87a1ee0b3d09bfa79d64bf41adf24bd3a75d54bc87f72fe74bf183d0L76-R78) [[3]](diffhunk://#diff-bbd0729f87a1ee0b3d09bfa79d64bf41adf24bd3a75d54bc87f72fe74bf183d0L85-R87)

**NTuple Initialization and Config Loading**

* Updated the `NTuple` class to avoid mutable default arguments for selectors and preprocessors, and to use the custom `CONFIG` object for tree name and configuration-driven loading. (`dtpr/base/ntuple.py`) [[1]](diffhunk://#diff-0ec8f91651c02d91e3c81f4b4ca1764bb449a61b1e461806bc3752a06d0e1bf1L39-R47) [[2]](diffhunk://#diff-0ec8f91651c02d91e3c81f4b4ca1764bb449a61b1e461806bc3752a06d0e1bf1L59-R59)
* Modified config loading methods in `NTuple` to reference the correct configuration object, improving reliability when multiple configurations are used. (`dtpr/base/ntuple.py`) [[1]](diffhunk://#diff-0ec8f91651c02d91e3c81f4b4ca1764bb449a61b1e461806bc3752a06d0e1bf1L104-R104) [[2]](diffhunk://#diff-0ec8f91651c02d91e3c81f4b4ca1764bb449a61b1e461806bc3752a06d0e1bf1L119-R119)